### PR TITLE
Fixes various issues from validation

### DIFF
--- a/osc_builder/stac.py
+++ b/osc_builder/stac.py
@@ -42,7 +42,6 @@ VARIABLES_PROP = f"{PREFIX}variables"
 STATUS_PROP = f"{PREFIX}status"
 REGION_PROP = f"{PREFIX}region"
 MISSIONS_PROP = f"{PREFIX}missions"
-STANDARD_NAME_PROP = f"{PREFIX}standard_name"
 
 OSC_SCHEME_THEMES = "https://github.com/stac-extensions/osc#theme"
 OSC_SCHEME_VARIABLES = "https://github.com/stac-extensions/osc#variable"
@@ -103,11 +102,12 @@ class CollectionOSCExtension(OSCExtension[pystac.Collection]):
                 PROJECT_PROP: product.project,
                 VARIABLES_PROP: product.variables,
                 STATUS_PROP: product.status.value.lower(),
-                REGION_PROP: product.region,
                 TYPE_PROP: "product",
-                STANDARD_NAME_PROP: product.standard_name,
+                NAME_PROP: product.standard_name,
             }
         )
+        if product.region:
+            self.properties[REGION_PROP] = product.region
         self.collection.keywords = product.keywords
 
         # add_theme_themes(self.collection, product.themes)
@@ -153,6 +153,27 @@ class CollectionOSCExtension(OSCExtension[pystac.Collection]):
             )
 
     def apply_project(self, project: Project):
+        contacts = []
+
+        if project.technical_officer.name:
+            officer = {
+                "name": project.technical_officer.name,
+                "role": "technical_officer",
+            }
+            if project.technical_officer.e_mail:
+                officer["emails"] = [
+                    {
+                        "value": project.technical_officer.e_mail,
+                    }
+                ]
+            contacts.append(officer)
+
+        for consortium_member in project.consortium:
+            contacts.append({
+                "name": consortium_member,
+                "role": "consortium_member",
+            })
+        
         self.properties.update(
             {
                 "title": project.title,
@@ -161,24 +182,7 @@ class CollectionOSCExtension(OSCExtension[pystac.Collection]):
                 STATUS_PROP: project.status.value.lower(),
                 THEMES_PROP: project.themes,
                 TYPE_PROP: "project",
-                "contacts": [
-                    {
-                        "name": project.technical_officer.name,
-                        "role": "technical_officer",
-                        "emails": [
-                            {
-                                "value": project.technical_officer.e_mail,
-                            }
-                        ],
-                    }
-                ]
-                + [
-                    {
-                        "name": consortium_member,
-                        "role": "consortium_member",
-                    }
-                    for consortium_member in project.consortium
-                ],
+                "contacts": contacts,
             }
         )
         # add_theme_themes(self.collection, project.themes)
@@ -256,11 +260,11 @@ def collection_from_product(product: Product) -> pystac.Collection:
         slug,
         product.description,
         extent=pystac.Extent(
-            pystac.SpatialExtent(
+            pystac.SpatialExtent([
                 product.geometry.bounds
                 if product.geometry
                 else [-180.0, -90.0, 180.0, 90.0]
-            ),
+            ]),
             pystac.TemporalExtent([[product.start, product.end]]),
         ),
         title=product.title,
@@ -282,7 +286,7 @@ def collection_from_project(project: Project) -> pystac.Item:
         project.description,
         extent=pystac.Extent(
             # todo: ESA should provide this
-            pystac.SpatialExtent([-180.0, -90.0, 180.0, 90.0]),
+            pystac.SpatialExtent([[-180.0, -90.0, 180.0, 90.0]]),
             pystac.TemporalExtent([[project.start, project.end]]),
         ),
         title=project.title,
@@ -313,14 +317,15 @@ def catalog_from_theme(theme: Theme) -> pystac.Catalog:
                 },
             )
         )
-    catalog.add_link(
-        pystac.Link(
-            rel=pystac.RelType.VIA,
-            target=theme.link,
-            media_type="text/html",
-            title="Description",
+    if theme.link:
+        catalog.add_link(
+            pystac.Link(
+                rel=pystac.RelType.VIA,
+                target=theme.link,
+                media_type="text/html",
+                title="Description",
+            )
         )
-    )
     return catalog
 
 
@@ -331,14 +336,15 @@ def catalog_from_variable(variable: Variable) -> pystac.Catalog:
         title=variable.name,
     )
     add_theme_themes(catalog, variable.themes)
-    catalog.add_link(
-        pystac.Link(
-            rel=pystac.RelType.VIA,
-            target=variable.link,
-            media_type="text/html",
-            title="Description",
+    if variable.link:
+        catalog.add_link(
+            pystac.Link(
+                rel=pystac.RelType.VIA,
+                target=variable.link,
+                media_type="text/html",
+                title="Description",
+            )
         )
-    )
     return catalog
 
 

--- a/osc_builder/stac.py
+++ b/osc_builder/stac.py
@@ -32,6 +32,9 @@ THEMES_SCHEMA_URI: str = (
 CONTACTS_SCHEMA_URI: str = (
     "https://stac-extensions.github.io/contacts/v0.1.1/schema.json"
 )
+CF_SCHEMA_URI: str = (
+    "https://stac-extensions.github.io/cf/v1.0.0/schema.json"
+)
 PREFIX: str = "osc:"
 
 TYPE_PROP = f"{PREFIX}type"
@@ -42,6 +45,7 @@ VARIABLES_PROP = f"{PREFIX}variables"
 STATUS_PROP = f"{PREFIX}status"
 REGION_PROP = f"{PREFIX}region"
 MISSIONS_PROP = f"{PREFIX}missions"
+STANDARD_NAME_PROP = "cf:parameter"
 
 OSC_SCHEME_THEMES = "https://github.com/stac-extensions/osc#theme"
 OSC_SCHEME_VARIABLES = "https://github.com/stac-extensions/osc#variable"
@@ -103,9 +107,14 @@ class CollectionOSCExtension(OSCExtension[pystac.Collection]):
                 VARIABLES_PROP: product.variables,
                 STATUS_PROP: product.status.value.lower(),
                 TYPE_PROP: "product",
-                NAME_PROP: product.standard_name,
             }
         )
+        if product.standard_name:
+            # ToDo: Add the schema to stac_extensions once released
+            # self.collection.stac_extensions.append(CF_SCHEMA_URI)
+            self.properties[STANDARD_NAME_PROP] = {
+                "name": product.standard_name,
+            }
         if product.region:
             self.properties[REGION_PROP] = product.region
         self.collection.keywords = product.keywords


### PR DESCRIPTION
Should fix the following:
- invalid bbox (missing outer array)
- osc:region is not allowed to be null
- osc:standard_name -> cf:parameter
- don't create technical officer entry if no data is provided + only add email if present
- Don't generate via links if no href is provided

Not solved: 
- osc:status = planned (needs https://github.com/stac-extensions/osc/pull/7, a release and a version number upgrade)
- Source data issues (no description or invalid email addresses)
- Childs in eo_missions
- too long paths on Windows
- CF Extension release (schema URI missing)

I wasn't able to test it yet due to the "too long paths on Windows" issue