### PR TITLE
cf:parameter in summaries

### DIFF
--- a/osc_builder/stac.py
+++ b/osc_builder/stac.py
@@ -13,7 +13,6 @@ from pystac.extensions.base import (
     PropertiesExtension,
 )
 import pystac.stac_io
-from pystac.summaries import Summaries
 import pystac.link
 
 from .types import Product, Project, Theme, Variable, EOMission
@@ -34,7 +33,7 @@ CONTACTS_SCHEMA_URI: str = (
     "https://stac-extensions.github.io/contacts/v0.1.1/schema.json"
 )
 CF_SCHEMA_URI: str = (
-    "https://stac-extensions.github.io/cf/v0.1.0/schema.json"
+    "https://stac-extensions.github.io/cf/v0.2.0/schema.json"
 )
 PREFIX: str = "osc:"
 
@@ -113,13 +112,11 @@ class CollectionOSCExtension(OSCExtension[pystac.Collection]):
 
         if product.standard_name:
             self.collection.stac_extensions.append(CF_SCHEMA_URI)
-            if not isinstance(self.collection.summaries, Summaries):
-                self.collection.summaries = Summaries()
-            self.collection.summaries.add(STANDARD_NAME_PROP, [
+            self.collection[STANDARD_NAME_PROP] = [
                 {
                     "name": product.standard_name,
                 }
-            ])
+            ]
 
         if product.region:
             self.properties[REGION_PROP] = product.region

--- a/osc_builder/stac.py
+++ b/osc_builder/stac.py
@@ -13,6 +13,7 @@ from pystac.extensions.base import (
     PropertiesExtension,
 )
 import pystac.stac_io
+from pystac.summaries import Summaries
 import pystac.link
 
 from .types import Product, Project, Theme, Variable, EOMission
@@ -109,13 +110,17 @@ class CollectionOSCExtension(OSCExtension[pystac.Collection]):
                 TYPE_PROP: "product",
             }
         )
+
         if product.standard_name:
             self.collection.stac_extensions.append(CF_SCHEMA_URI)
-            self.properties[STANDARD_NAME_PROP] = [
+            if not isinstance(self.collection.summaries, Summaries):
+                self.collection.summaries = Summaries()
+            self.collection.summaries.add(STANDARD_NAME_PROP, [
                 {
                     "name": product.standard_name,
                 }
-            ]
+            ])
+
         if product.region:
             self.properties[REGION_PROP] = product.region
         self.collection.keywords = product.keywords

--- a/osc_builder/stac.py
+++ b/osc_builder/stac.py
@@ -112,7 +112,7 @@ class CollectionOSCExtension(OSCExtension[pystac.Collection]):
 
         if product.standard_name:
             self.collection.stac_extensions.append(CF_SCHEMA_URI)
-            self.collection[STANDARD_NAME_PROP] = [
+            self.properties[STANDARD_NAME_PROP] = [
                 {
                     "name": product.standard_name,
                 }


### PR DESCRIPTION
So according to the CF extension we can't just place the cf:parameter in the collection without having a corresponding asset.

Either we need to ask to relax this, or we need to put them in summaries.